### PR TITLE
improve the search for rhoam clusters

### DIFF
--- a/rhoam-cluster-list.sh
+++ b/rhoam-cluster-list.sh
@@ -20,7 +20,7 @@ ocm list clusters --columns 'id,state' --managed --no-headers | while read -r id
     continue
   fi
   
-  addon_status=$(ocm list addons --cluster "$id" | grep 'managed-api-service') 
+  addon_status=$(ocm list addons --cluster "$id" | grep -w 'managed-api-service') 
   if [ -n "$addon_status" ] && ! echo "$addon_status" | grep -qE 'not installed|uninstalled'; then
     
     cluster_details=$(ocm describe cluster "$id")

--- a/rhoam-cluster-list.sh
+++ b/rhoam-cluster-list.sh
@@ -20,7 +20,8 @@ ocm list clusters --columns 'id,state' --managed --no-headers | while read -r id
     continue
   fi
   
-  if ocm list addons --cluster "$id" | grep 'managed-api-service' | grep -q 'ready'; then
+  addon_status=$(ocm list addons --cluster "$id" | grep 'managed-api-service') 
+  if [ -n "$addon_status" ] && ! echo "$addon_status" | grep -qE 'not installed|uninstalled'; then
     
     cluster_details=$(ocm describe cluster "$id")
     cluster_name=$(echo "$cluster_details" | grep '^Name:' | awk '{$1=""; print $0}' | xargs)


### PR DESCRIPTION
run and see if it finds rhoam addons in another state other than ready. 

Only states that shouldn't show up are `not installed` and `uninstalled` 